### PR TITLE
Add "Generic resource" type and form with basic fields

### DIFF
--- a/intra-includes/create.inc
+++ b/intra-includes/create.inc
@@ -57,6 +57,11 @@
           [% ELSE %]
           <option value="other">Other</option>
           [% END %]
+          [% IF whole.value.other.type.lower == "resource" %]
+          <option value="resource" selected="selected">Generic resource</option>
+          [% ELSE %]
+          <option value="resource">Generic resource</option>
+          [% END %]
         </select>
       </li>
     </ol>

--- a/intra-includes/edititem.inc
+++ b/intra-includes/edititem.inc
@@ -50,6 +50,11 @@
           [% ELSE %]
           <option value="other">Other</option>
           [% END %]
+          [% IF whole.value.other.type.lower == "resource" %]
+          <option value="resource" selected="selected">Generic resource</option>
+          [% ELSE %]
+          <option value="resource">Generic resource</option>
+          [% END %]
         </select>
       </li>
     </ol>

--- a/intra-includes/migrate.inc
+++ b/intra-includes/migrate.inc
@@ -57,6 +57,11 @@
           [% ELSE %]
           <option value="other">Other</option>
           [% END %]
+          [% IF whole.value.other.type.lower == "resource" %]
+          <option value="resource" selected="selected">Generic resource</option>
+          [% ELSE %]
+          <option value="resource">Generic resource</option>
+          [% END %]          
         </select>
       </li>
     </ol>

--- a/opac-includes/create.inc
+++ b/opac-includes/create.inc
@@ -57,6 +57,11 @@
           [% ELSE %]
           <option value="other">Other</option>
           [% END %]
+          [% IF whole.value.other.type.lower == "resource" %]
+          <option value="resource" selected="selected">Generic resource</option>
+          [% ELSE %]
+          <option value="resource">Generic resource</option>
+          [% END %]
         </select>
       </li>
     </ol>

--- a/shared-includes/forms/resource.inc
+++ b/shared-includes/forms/resource.inc
@@ -1,0 +1,53 @@
+<fieldset id="resource-freeform-fieldset" class="rows">
+    <legend>Generic resource details</legend>
+    <ol id="resource-freeform-fields">
+        <li>
+            <label for="title">Title:</label>
+            <input type="text" name="title" value="[% whole.value.other.title %]" />
+        </li>
+        <li>
+            <label for="author">Author:</label>
+            <input type="text" name="author" id="author" value="[% whole.value.other.author %]" />
+        </li>
+        <li>
+            <label for="editor">Editor:</label>
+            <input type="text" name="editor" id="editor" value="[% whole.value.other.editor %]" />
+        </li>
+        <li>
+            <label for="publisher">Publisher:</label>
+            <input type="text" name="publisher" id="publisher" value="[% whole.value.other.publisher %]" />
+        </li>
+        <li>
+            <label for="published_place">Place of publication:</label>
+            <input type="text" name="published_place" id="published_place" value="[% whole.value.other.published_place %]" />
+        </li>
+        <li>
+            <label for="year">Year:</label>
+            <input type="text" name="year" id="year" value="[% whole.value.other.year %]" />
+        </li>
+        <li>
+            <label for="part_edition">Part / Edition:</label>
+            <input type="text" name="part_edition" id="part_edition" value="[% whole.value.other.part_edition %]" />
+        </li>
+        <li>
+            <label for="volume">Volume:</label>
+            <input type="text" name="volume" id="volume" value="[% whole.value.other.volume %]" />
+        </li>
+        <li>
+            <label for="pages">Pages:</label>
+            <input type="text" name="pages" id="pages" value="[% whole.value.other.pages %]" />
+        </li>
+        <li>
+            <label for="isbn">ISBN:</label>
+            <input type="text" name="isbn" id="isbn" value="[% whole.value.other.isbn %]" />
+        </li>
+        <li>
+            <label for "issn">ISSN:</label>
+            <input type="text" name="issn" id="issn" value="[% whole.value.other.issn %]" />
+        </li>
+        <li>
+            <label for="doi">DOI:</label>
+            <input type="text" name="doi" id="doi" value="[% whole.value.other.doi %]" />
+        </li>
+    </ol>
+</fieldset>       


### PR DESCRIPTION
Adds a "Generic resource" type that links to a form with basic fields. Intended for use by patrons who would prefer to see basic fields to fill in instead of defining their own fields in "Other," and also for a fallback type to use in OpenURL query string development. Emerged from discussion at Koha-US 2019.