### PR TITLE
Dont show redundant fields under details from supplier

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -145,7 +145,7 @@ sub metadata {
     my ( $self, $request ) = @_;
     my $attrs       = $request->illrequestattributes;
     my $metadata    = {};
-    my @ignore      = ('requested_partners');
+    my @ignore      = ('requested_partners', 'type', 'type_disclaimer_value', 'type_disclaimer_date');
 	my $core_fields = _get_core_fields();
     while ( my $attr = $attrs->next ) {
         my $type = $attr->type;


### PR DESCRIPTION
type, type_disclaimer_value and type_disclaimer_date should already be showing under 'request details' so we dont need to show them here again Please note that, without bug 35107, type_disclaimer_value and type_disclaimer_date are not visible from FreeForm with this patch