### PR TITLE
Followup fix of ill_batch_id param

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -979,7 +979,9 @@ sub add_request {
     $request->backend( $params->{other}->{backend} );
     $request->placed( DateTime->now );
     $request->updated( DateTime->now );
-    $request->batch_id( $params->{other}->{ill_batch_id} ) if column_exists( 'illrequests', 'batch_id' );
+    $request->batch_id(
+        $params->{other}->{ill_batch_id} ? $params->{other}->{ill_batch_id} : $params->{other}->{batch_id} )
+        if column_exists( 'illrequests', 'batch_id' );
     $request->store;
 
     while ( my ( $type, $value ) = each %{$request_details} ) {


### PR DESCRIPTION
QA work on 30719 changed the API param being sent from batch_id to ill_batch_id. Here, check for either because live systems with 30719 backported may still be using the old batch_id